### PR TITLE
Change negative values to zero

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,10 +5,10 @@ module.exports = function (rgbString) {
 	// First remove all whitespace, then parse the rgb string
 	rgbString = rgbString.replace(/ /g, '');
 
-	rgbString.replace(/rgb\((\d+),(\d+),(\d+)\)/, function (rgbString, r, g, b) {
-		rgb.red = Number(r);
-		rgb.green = Number(g);
-		rgb.blue = Number(b);
+	rgbString.replace(/rgb\((\d+|-\d+),(\d+|-\d+),(\d+|-\d+)\)/, function (rgbString, r, g, b) {
+		rgb.red = r > 0 ? Number(r) : 0;
+		rgb.green = g > 0 ? Number(g) : 0;
+		rgb.blue = b > 0 ? Number(b) : 0;
 	});
 
 	return rgb;

--- a/index.js
+++ b/index.js
@@ -5,10 +5,10 @@ module.exports = function (rgbString) {
 	// First remove all whitespace, then parse the rgb string
 	rgbString = rgbString.replace(/ /g, '');
 
-	rgbString.replace(/rgb\((\d+|-\d+),(\d+|-\d+),(\d+|-\d+)\)/, function (rgbString, r, g, b) {
-		rgb.red = r > 0 ? Number(r) : 0;
-		rgb.green = g > 0 ? Number(g) : 0;
-		rgb.blue = b > 0 ? Number(b) : 0;
+	rgbString.replace(/rgb\((-?\d+),(-?\d+),(-?\d+)\)/, function (rgbString, r, g, b) {
+		rgb.red = Number(r);
+		rgb.green = Number(g);
+		rgb.blue = Number(b);
 	});
 
 	return rgb;

--- a/test.js
+++ b/test.js
@@ -30,9 +30,9 @@ test('ignores whitespace around comma\'s', function (t) {
 	t.assert(result.blue === 3);
 });
 
-test('change negative numbers to zero', function (t) {
-	var result = parseRgb('rgb(-10 , 2   ,3  )');
-	t.assert(result.red === 0);
-	t.assert(result.green === 2);
+test('should return actual negative value', function (t) {
+	var result = parseRgb('rgb(-10 , -22   ,3  )');
+	t.assert(result.red === -10);
+	t.assert(result.green === -22);
 	t.assert(result.blue === 3);
 });

--- a/test.js
+++ b/test.js
@@ -29,3 +29,10 @@ test('ignores whitespace around comma\'s', function (t) {
 	t.assert(result.green === 2);
 	t.assert(result.blue === 3);
 });
+
+test('change negative numbers to zero', function (t) {
+	var result = parseRgb('rgb(-10 , 2   ,3  )');
+	t.assert(result.red === 0);
+	t.assert(result.green === 2);
+	t.assert(result.blue === 3);
+});


### PR DESCRIPTION
Right for now when user puts negative values into string, it return empty object.
For example,`'rgb(-20, 30, 40)'` will return `=> {}`
My suggestion is to replace negative values on zeros.
For example `'rgb(-30, 40, 60)'` => `{red: 0, green: 40, blue: 60}`
